### PR TITLE
Added power support for the travis.yml file with ppc64le  and excluded the job  go: 1.10.8 for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,11 @@ go:
 - 1.10.8
 - 1.11.6
 - 1.12.1
+# Disable GO version 1.2,1.3 &1.4
+jobs:
+  exclude:
+    - arch: ppc64le
+      go: 1.10.8
+
 script:
 - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+ - amd64
+ - ppc64le
 go:
 - 1.10.8
 - 1.11.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.10.8
 - 1.11.6
 - 1.12.1
-# Disable GO version 1.2,1.3 &1.4
+# Disable GO version 1.10.8
 jobs:
   exclude:
     - arch: ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

 excluded the job  go: 1.10.8 for ppc64le